### PR TITLE
[Feat] Command Line Interface (CLI)

### DIFF
--- a/LEARNING.md
+++ b/LEARNING.md
@@ -16,3 +16,8 @@
  - https://github.com/Engelberg/instaparse/issues/109
  - https://gist.github.com/Jared314/5606912
  - https://github.com/Engelberg/instaparse#output-format (use the :enlive format)
+
+## CLI
+
+ - https://yobriefca.se/blog/2014/03/02/building-command-line-apps-with-clojure/
+ - http://markwoodhall.com/26-06-2014-command-line-applications-in-clojure/

--- a/README.md
+++ b/README.md
@@ -275,13 +275,36 @@ Only one `!Play` definition is allowed per track file.
 
 ## Usage
 
+### CLI
+
+First be sure that you have a binary executable (requires `lein` to be installed) available on your `PATH`:
+
+```sh
+$ cd warble
+$ lein bin
+```
+
+Then you can just execute the resulting binary like so:
+
+```sh
+$ target/warble -i /path/to/track.warb compile
+```
+
+Currently supports the following actions:
+
+- `parse`: creates an Abstract Syntax Tree (AST) from vanilla `warble` data
+- `compile`: parses and compiles vanilla `warble` data into `warble.json`, an intermediary JSON micro-format that allows for simple interpretation of tracks
+- `help`
+
+### Library
+
 ```clojure
 (ns my.namespace
-  (:require [warble.lexer :as lexer]
+  (:require [warble.lexer :as ast]
             [warble.track :refer [compile-track]]))
 
 ; parses and compiles raw warble data into an interpretable hash-map
-(compile-track (lexer/parse ":Foo = []"))
+(compile-track (ast/parse ":Foo = []"))
 ```
 
 ## Related

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Of course, it is intuitive and easy to write for non-technical people as well!
 - Simple, composable and scalable constructs
 - Trivial to interpret compiled output. Writing `warble` engines should be easy!
 - Allow for alternative representations of music (i.e. visual instead of just audio)
-- Seamless syncronization with associated audio tracks by minimizing the complexities around timing
+- Seamless synchronization with associated audio tracks by minimizing the complexities around timing
 - Keep things DRY
 
 ## Install

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
+                 [org.clojure/tools.cli "0.3.5"]
                  [instaparse "1.4.3"]]
   :main ^:skip-aot warble.core
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
                  [instaparse "1.4.3"]]
   :main ^:skip-aot warble.core
   :target-path "target/%s"
+  :plugins [[lein-bin "0.3.5"]]
   :profiles {:uberjar {:aot :all}})

--- a/src/warble/core.clj
+++ b/src/warble/core.clj
@@ -7,7 +7,7 @@
   (:gen-class))
 
 (def cli-options
-  [["-i" "--input FILE" "The file to use as input"
+  [["-i" "--input DATA" "The warble data to use as input"
     :id :input
     :default ""]
    ["-h" "--help"]])

--- a/src/warble/core.clj
+++ b/src/warble/core.clj
@@ -1,7 +1,57 @@
 (ns warble.core
+  (:require [clojure.tools.cli :refer [parse-opts]]
+            [clojure.string :as string]
+            [warble.lexer :as ast]
+            [warble.track :refer [compile-track]]
+            [warble.translate :refer [to-json]])
   (:gen-class))
 
-(defn -main
-  "Warble"
-  [& args]
-  (println "[warble] lexer and parser. start by importing the warble/lexer and warble/track modules into your namespace"))
+(def cli-options
+  [["-i" "--input FILE" "The file to use as input"
+    :id :input
+    :default ""]
+   ["-h" "--help"]])
+
+(def handlers
+  {:parse (fn [data]
+            (let [input (:input data)
+                  output (ast/parse (slurp input))]
+              (println output)))
+   :compile (fn [data]
+              (let [input (:input data)
+                    parsed (ast/parse (slurp input))
+                    output (-> parsed compile-track to-json)]
+                (println output)))})
+
+(defn help [options]
+  (->> ["warble is a pragmatic notation for representing musical tracks and loops"
+        ""
+        "Usage: warble [options] action"
+        ""
+        "Options:"
+        options
+        ""
+        "Actions:"
+        "  parse        Parses plain-text warble data into an Abstract Syntax Tree (AST)"
+        "  compile      Compiles plain-text warble data into warble.json, an easy to interpret JSON micro-format"]
+       (string/join \newline)))
+
+(defn error-msg [errors]
+  (str "There were errors processing the command line arguments\n\n"
+       (string/join \newline errors)))
+
+(defn exit [status msg]
+  (println msg)
+  (System/exit status))
+
+(defn -main [& args]
+  "warble"
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (cond
+      (:help options) (exit 0 (help summary))
+      (not= (count arguments) 1) (exit 1 (help summary))
+      errors (exit 1 (error-msg errors)))
+    (let [handler ((keyword (first arguments)) handlers)]
+      (if handler
+        (handler options)
+        (exit 0 (help summary))))))


### PR DESCRIPTION
### Changes
- :art: created a basic CLI that supports `parse`, `compile` and `help` actions
  * `-i` or `--input` to specify the source data
  * `parse`, `compile` and `help` are the available actions

### Examples
- `$ warble -i tracks/blues-jam.warb parse`
- `$ warble -i tracks/blues-jam.warb compile`
- `$ warble help`
