### PR TITLE
[Syntax] Element attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ Destructured list assignments will soon be supported and will also favor cadence
 :[A, B, C, D] = [Chord('E7'), Chord('Emin7'), Chord('Cmaj7'), Chord('Dmaj7')]
 ```
 
-### Color Labeling
+### Attributes
 
-Colors are useful for succesfully expressing a variety of data to the user at once.
+Arbitrary attributes may be associated with `Elements` using the `<key>: <value>` syntax.
 
-Colors are expresssed as `attributes` (i.e. `<key>: <value>`), using the key `color`:
+For instance, colors are useful for succesfully expressing a variety of data to the user at once.
 
 ```
 :ABC = [

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ In music it's common to see cadence sections labeled as `A`, `B`, `C`, and so on
 :C = Chord('C2maj')
 
 :Song = [
-  1 -> :A,
-  1 -> :B,
+  1 -> :A
+  1 -> :B
   1 -> :C
   1 -> :A
 ]
@@ -177,16 +177,18 @@ Destructured list assignments will soon be supported and will also favor cadence
 
 ### Color Labeling
 
-Colors are useful for succesfully expressing a variety of data to the user at once:
+Colors are useful for succesfully expressing a variety of data to the user at once.
+
+Colors are expresssed as `attributes`:
 
 ```
 :ABC = [
   1 -> {
-    Scale('C2min',  #6CB359),
-    Chord('D2min7', #AA5585)
+    Scale('C2min',  color: #6CB359)
+    Chord('D2min7', color: #AA5585)
   },
-  1 -> Chord('G2Maj7', #D48B6A),
-  2 -> Chord('C2Maj7', #FFDCAA)
+  1 -> Chord('G2Maj7', color: #D48B6A)
+  2 -> Chord('C2Maj7', color: #FFDCAA)
 ]
 ```
 
@@ -202,7 +204,11 @@ Optional meta information about the track (aka "headers"), including the tempo a
 @Tempo = 90
 @Tags  = ['test', 'lullaby']
 
-:ABC = [1/2 -> Chord('D2Mmin7'), 1/2 -> Chord('G2Min7'), 1 -> Chord('C2Maj7')]
+:ABC = [
+  1/2 -> Chord('D2Mmin7')
+  1/2 -> Chord('G2Min7')
+  1 -> Chord('C2Maj7')
+]
 ```
 
 ### Play

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Destructured list assignments will soon be supported and will also favor cadence
 
 Colors are useful for succesfully expressing a variety of data to the user at once.
 
-Colors are expresssed as `attributes` (i.e. `<key>: <value>`):
+Colors are expresssed as `attributes` (i.e. `<key>: <value>`), using the key `color`:
 
 ```
 :ABC = [

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Destructured list assignments will soon be supported and will also favor cadence
 
 Colors are useful for succesfully expressing a variety of data to the user at once.
 
-Colors are expresssed as `attributes`:
+Colors are expresssed as `attributes` (i.e. `<key>: <value>`):
 
 ```
 :ABC = [

--- a/README.md
+++ b/README.md
@@ -181,18 +181,18 @@ Arbitrary attributes may be associated with `Elements` using the `<key>: <value>
 
 For instance, colors are useful for succesfully expressing a variety of data to the user at once.
 
+You might also want to specify the specific voicing of a chord.
+
 ```
 :ABC = [
   1 -> {
     Scale('C2min',  color: #6CB359)
-    Chord('D2min7', color: #AA5585)
+    Chord('D2min7', color: #AA5585, voicing: 1)
   },
-  1 -> Chord('G2Maj7', color: #D48B6A)
-  2 -> Chord('C2Maj7', color: #FFDCAA)
+  1 -> Chord('G2Maj7', color: #D48B6A, voicing: 2)
+  2 -> Chord('C2Maj7', color: #FFDCAA, voicing: 2)
 ]
 ```
-
-Color values must be hexadecimal (no `red`, `blue`, etc. for now).
 
 ### Meta
 

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -12,8 +12,9 @@ list       = [<empty>] <'['> [elem (<','|empty> elem)* [<','>]] <']'> [<empty>]
 pair       = term <'->'> elem [<empty>,<empty>]
 assign     = identifier <'='> elem
 header     = meta <'='> elem
+attribute  = word [<empty>] <':'> [<empty>] prim
 identifier = [<empty>] #':[a-zA-Z]+' [<empty>]
-arguments  = ((identifier | string | color | add-sub) [<empty> <','> <empty>])*
+arguments  = ((identifier | string | attribute | add-sub) [<empty> <','> <empty>])*
 init       = <'('> arguments <')'>
 meta       = [<empty>] <'@'> #'(Audio|Instrument|Time|Tempo|Key|Delay|Link|Title|Desc|Tags)' [<empty>]
 keyword    = [<empty>] #'(`|~|Note|Scale|Chord|Mode|Triad)' [<empty>]

--- a/test/warble/ast_test.clj
+++ b/test/warble/ast_test.clj
@@ -71,5 +71,5 @@
     (let [want [:track [:statement [:atom [:keyword "Scale"] [:init [:arguments [:string "'C2 Major'"]]]]]]]
       (is (= (parse "Scale('C2 Major')") want))))
   (testing "multiple arguments"
-    (let [want [:track [:statement [:atom [:keyword "Scale"] [:init [:arguments [:string "'C2 Minor'"] [:div [:number "1"] [:number "4"]] [:color "#FF0000"]]]]]]]
-      (is (= (parse "Scale('C2 Minor', 1/4, #FF0000)") want)))))
+    (let [want [:track [:statement [:atom [:keyword "Scale"] [:init [:arguments [:string "'C2 Minor'"] [:div [:number "1"] [:number "4"]] [:attribute [:word "color"] [:color "#FF0000"]]]]]]]]
+      (is (= (parse "Scale('C2 Minor', 1/4, color: #FF0000)") want)))))


### PR DESCRIPTION
## Change

Introducing the attributes construct:

`<key>: <value>`

This construct allows users to provide arbitrary attributes to their `Elements` (`Scale`, `Chord`, `Note`, etc.)

This is useful for meta-descriptive info such as `color`, `voicing`, `shape`, and more.

## Example

```
Chord('C2min7', color: #FF0000, voicing: 1)
```